### PR TITLE
RPC: prevent replying more than one time on a request timeout

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -77,18 +77,27 @@ function exchange(name, type, options) {
       options = DEFAULT_RPC_CLIENT_OPTIONS;
     }
 
+    let replied = false;
+
     var timeout = setTimeout(() => {
       replyTo(new Error('Timeout'));
+      replied = true;
     }, options.timeout || DEFAULT_RPC_CLIENT_OPTIONS.timeout);
 
-    function onReply (reply) {
+    function onReply(reply) {
       clearTimeout(timeout);
-      replyTo(reply);
+
+      if (!replied) {
+        replyTo(reply);
+      }
     }
 
-    function onNotFound (notFound) {
+    function onNotFound(notFound) {
       clearTimeout(timeout);
-      replyTo(new Error('Not Found'));
+
+      if (!replied) {
+        replyTo(new Error('Not Found'));
+      }
     }
 
     publish(msg, {


### PR DESCRIPTION
- add flag to prevent replying more than one time when a RPC request times out