### PR TITLE
fix: strict mode err

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var amqp = require('amqplib/callback_api');
 var extend = require('lodash.assignin');
 var EventEmitter = require('events').EventEmitter;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "amqplib": "^0.5.1",
     "lodash.assignin": "4.x.x",
-    "uuid": "^3.0.1"
+    "uuid": "3.x.x"
   },
   "devDependencies": {
     "chai": "3.x.x",


### PR DESCRIPTION
Closes Node v4 incompat error:

```
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
```