### PR TITLE
chore: pin uuid min version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "amqplib": "^0.5.1",
     "lodash.assignin": "4.x.x",
-    "uuid": "3.x.x"
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "chai": "3.x.x",


### PR DESCRIPTION
There was a regression in https://github.com/pagerinc/jackrabbit/commit/2ba0c7e77cc376767af9993bba16030c74ffb773

This solves a problem when this package is added to a project that uses the `raven` package or another package that requires `uuid`:`3.0.0`.

The uuid version needs to be at least `3.0.1` per this:
https://github.com/kelektiv/node-uuid/commit/681bddd6f4cf3abb8c1af93c30d035b695cbe756