### PR TITLE
Fix for when close is called before connection established

### DIFF
--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -33,6 +33,10 @@ function jackrabbit(url) {
   }
 
   function close(callback) {
+    if (!connection) {
+      if (callback) callback();
+      return;
+    }
     try {
       // I don't think amqplib should be throwing here, as this is an async function
       // TODO: figure out how to test whether or not amqplib will throw


### PR DESCRIPTION
Currently - if you call `rabbit.close()` prior to a connection being established, connection will be undefined.