### PR TITLE
fix: queue.consume now works when executed after queue is ready

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -23,7 +23,7 @@ module.exports = queue;
 
 function queue(options) {
   options = options || {};
-  let channel, consumerTag;
+  let channel, consumerTag, ready;
   const emitter = extend(new EventEmitter(), {
     name: options.name,
     options: extend({}, DEFAULT_QUEUE_OPTIONS, options),
@@ -40,10 +40,17 @@ function queue(options) {
   }
 
   function consume(callback, options) {
-    emitter.once('ready', function() {
+    if( ready ){
       const opts = extend({}, DEFAULT_CONSUME_OPTIONS, options);
       channel.consume(emitter.name, onMessage, opts, onConsume);
-    });
+    }
+
+    else {
+      emitter.once('ready', function() {
+        const opts = extend({}, DEFAULT_CONSUME_OPTIONS, options);
+        channel.consume(emitter.name, onMessage, opts, onConsume);
+      });
+    }
 
     function onMessage(msg) {
       const data = parseMessage(msg);
@@ -140,6 +147,7 @@ function queue(options) {
   function onQueue(err, info) {
     if (err) return bail(err);
     emitter.name = info.queue;
+    ready = true;
     emitter.emit('ready');
   }
 }


### PR DESCRIPTION
Calling `queue.consume` after a queue is ready currently does nothing.

It's waiting for emitter to send a ready event, but emitter already did when it first connected.

My solution tracks if ready event has already been sent in a variable. 

`queue.consume` now knows if it should wait for ready event or execute immediately.