### PR TITLE
feat: mocha 6, implement lint stye, run lint in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,8 @@ defaults: &defaults
 jobs:
   test:
     <<: *defaults
+    environment:
+      RABBIT_URL=amqp://localhost
     steps:
     - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-  - image: circleci/node:10.16@sha256:d4e0feb0389eb1891d774a4588b81d769e2cb978b528fd7a5673b2b35453dab4
+  - image: circleci/node:10.16@sha256:564e5acb34511a45cac1e3b4c0969370ec798a9642064699d3ad17b84e5ef28d
   - image: rabbitmq:3.7-alpine@sha256:bc92e61664e10cd6dc7a9bba3d39a18a446552f9dc40d2eb68c19818556c3201
 
 jobs:
@@ -19,6 +19,7 @@ jobs:
         - v1-dependencies-
 
     - run: npm install
+    - run: npm run lint
     - run:
         name: Wait for RabbitMQ to receive connections
         command: dockerize -wait tcp://localhost:5672 -timeout 1m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
-jackrabbit:
-  image: node@sha256:6e64f63a663a368cc81b28ed3c3e29e6b3784c04f0128be5aaa659157ed4d231
-  working_dir: /code
-  volumes:
-    - .:/code
-  links:
-    - rabbit
-  environment:
-    RABBIT_URL: 'amqp://rabbit'
-rabbit:
-  image: rabbitmq@sha256:437ea77f0651165726384bab7863578aee792805451badf712e71ebe8b68931b
+version: '3'
+
+services:
+  jackrabbit:
+    build: .
+    environment:
+      RABBIT_URL: 'amqp://rabbit'
+    restart: on-failure
+  rabbit:
+    image: rabbitmq@sha256:437ea77f0651165726384bab7863578aee792805451badf712e71ebe8b68931b
+    ports:
+      - "5672:5672"

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -1,291 +1,344 @@
-'use strict'
+'use strict';
 
-const extend = require('lodash.assignin')
-const EventEmitter = require('events').EventEmitter
-const uuid = require('uuid/v4')
+const Extend = require('lodash.assignin');
+const EventEmitter = require('events').EventEmitter;
+const Uuid = require('uuid/v4');
 
-const queue = require('./queue')
+const Queue = require('./queue');
 
 const DEFAULT_EXCHANGES = {
-  'direct': 'amq.direct',
-  'fanout': 'amq.fanout',
-  'topic': 'amq.topic'
-}
+    'direct': 'amq.direct',
+    'fanout': 'amq.fanout',
+    'topic': 'amq.topic'
+};
 
 const DEFAULT_EXCHANGE_OPTIONS = {
-  durable: true,
-  internal: false,
-  autoDelete: false,
-  alternateExchange: undefined
-}
+    durable: true,
+    internal: false,
+    autoDelete: false,
+    alternateExchange: undefined
+};
 
 const DEFAULT_PUBLISH_OPTIONS = {
-  contentType: 'application/json',
-  mandatory: false,
-  persistent: false,
-  expiration: undefined,
-  userId: undefined,
-  CC: undefined,
-  BCC: undefined
-}
+    contentType: 'application/json',
+    mandatory: false,
+    persistent: false,
+    expiration: undefined,
+    userId: undefined,
+    CC: undefined,
+    BCC: undefined
+};
 
 const DEFAULT_RPC_CLIENT_OPTIONS = {
-  timeout: 3000
-}
+    timeout: 3000
+};
 
-module.exports = exchange
 
-function exchange (name, type, options) {
-  if (!type) {
-    throw new Error('missing exchange type')
-  }
-  if (!isNameless(name)) {
-    name = name || DEFAULT_EXCHANGES[type]
-    if (!name) {
-      throw new Error('missing exchange name')
-    }
-  }
+const isDefault = (name, type) => {
 
-  let ready = false
-  let connection, channel
-  let publishing = 0
-  const replyQueue = queue({ exclusive: true })
-  const pendingReplies = {}
+    return DEFAULT_EXCHANGES[type] === name;
+};
 
-  const emitter = extend(new EventEmitter(), {
-    name: name,
-    type: type,
-    options: extend({}, DEFAULT_EXCHANGE_OPTIONS, options),
-    queue: createQueue,
-    connect: connect,
-    publish: publish,
-    rpcClient: rpcClient,
-    rpcServer: rpcServer
-  })
+const isNameless = (name) => {
 
-  return emitter
+    return name === '';
+};
 
-  function rpcClient (key, msg, options, cb) {
-    if (!key) {
-      throw new Error('missing rpc method')
+const exchange = (name, type, options) => {
+
+    if (!type) {
+        throw new Error('missing exchange type');
     }
 
-    if (!cb && typeof options === 'function') {
-      cb = options
-    }
-
-    if (!options || typeof options !== 'object') {
-      options = DEFAULT_RPC_CLIENT_OPTIONS
-    }
-
-    const opts = extend({}, {
-      key: key,
-      rpcCallback: cb
-    }, options)
-
-    publish(msg, opts)
-  }
-
-  function rpcServer (key, handler) {
-    const rpcQueue = createQueue({
-      key: key,
-      name: key,
-      prefetch: 1,
-      durable: false,
-      autoDelete: true
-    })
-    rpcQueue.consume(handler)
-  }
-
-  function connect (con) {
-    connection = con
-    connection.createChannel(onChannel)
-    replyQueue.on('close', bail.bind(this))
-    replyQueue.consume(onReply, { noAck: true })
-    return emitter
-  }
-
-  function createQueue (options) {
-    const newQueue = queue(options)
-    newQueue.on('close', bail.bind(this))
-    newQueue.once('ready', function () {
-      // the default exchange has implicit bindings to all queues
-      if (!isNameless(emitter.name)) {
-        const keys = options.keys || [options.key]
-        bindKeys(keys)
-          .then(function emitBoundEvent (res) {
-            newQueue.emit('bound')
-          })
-          .catch(bail)
-      }
-    })
-
-    if (connection) {
-      newQueue.connect(connection)
-    } else {
-      emitter.once('ready', function () {
-        newQueue.connect(connection)
-      })
-    }
-    return newQueue
-
-    // return a promise when all keys are bound
-    function bindKeys (keys) {
-      return Promise.all(keys.map(bindKey))
-
-      // returns a promise when a key is bound
-      function bindKey (key) {
-        return new Promise(function (resolve, reject) {
-          channel.bindQueue(newQueue.name, emitter.name, key, {}, function onBind (err, ok) {
-            if (err) return reject(err)
-            return resolve(ok)
-          })
-        })
-      }
-    }
-  }
-
-  function publish (message, options) {
-    publishing++
-    options = options || {}
-
-    const sendMessageRef = options.rpcCallback ? sendRpcMessage : sendMessage
-
-    if (ready) {
-      sendMessageRef()
-    } else {
-      emitter.once('ready', sendMessageRef)
-    }
-
-    return emitter
-
-    function sendMessage () {
-      // TODO: better blacklisting/whitelisting of properties
-      const opts = extend({}, DEFAULT_PUBLISH_OPTIONS, options)
-      const msg = encodeMessage(message, opts.contentType)
-
-      if (opts.reply) {
-        opts.replyTo = replyQueue.name
-        opts.correlationId = uuid()
-        pendingReplies[opts.correlationId] = opts.reply
-        delete opts.reply
-      }
-
-      const drained = channel.publish(emitter.name, opts.key, new Buffer(msg), opts)
-      if (drained) onDrain()
-    }
-
-    function sendRpcMessage () {
-      const opts = extend({}, DEFAULT_PUBLISH_OPTIONS, options)
-      const msg = encodeMessage(message, opts.contentType)
-
-      let replied = false
-      const correlationId = uuid()
-      const rpcCallback = opts.rpcCallback
-
-      function onReply (reply) {
-        clearTimeout(timeout)
-        channel.removeListener('return', onNotFound)
-
-        if (!replied) {
-          replied = true
-          rpcCallback(reply)
+    if (!isNameless(name)) {
+        name = name || DEFAULT_EXCHANGES[type];
+        if (!name) {
+            throw new Error('missing exchange name');
         }
-      }
-
-      function onNotFound (notFound) {
-        clearTimeout(timeout)
-        clearPendingReply(correlationId)
-        channel.removeListener('return', onNotFound)
-
-        if (!replied) {
-          replied = true
-          rpcCallback(new Error('Not Found'))
-        }
-      }
-
-      const timeout = setTimeout(function () {
-        clearPendingReply(correlationId)
-        channel.removeListener('return', onNotFound)
-
-        if (!replied) {
-          replied = true
-          rpcCallback(new Error('Timeout'))
-        }
-      }, options.timeout || DEFAULT_RPC_CLIENT_OPTIONS.timeout)
-
-      opts.replyTo = replyQueue.name
-      opts.correlationId = correlationId
-      opts.mandatory = true
-
-      pendingReplies[opts.correlationId] = onReply
-      channel.once('return', onNotFound)
-
-      const drained = channel.publish(emitter.name, opts.key, new Buffer(msg), opts)
-      if (drained) onDrain()
     }
-  }
 
-  function encodeMessage (message, contentType) {
-    if (contentType === 'application/json') return JSON.stringify(message)
-    return message
-  }
+    let ready = false;
+    let channel; let connection;
+    let publishing = 0;
+    const replyQueue = Queue({ exclusive: true });
+    const pendingReplies = {};
 
-  function onReply (data, ack, nack, msg) {
-    const replyCallback = pendingReplies[msg.properties.correlationId]
-    if (replyCallback) replyCallback(data)
-    clearPendingReply(msg.properties.correlationId)
-  }
+    const rpcClient = (key, msg, rpcOptions, cb) => {
 
-  function clearPendingReply (correlationId) {
-    delete pendingReplies[correlationId]
-  }
+        if (!key) {
+            throw new Error('missing rpc method');
+        }
 
-  function bail (err) {
-    // TODO: close all queue channels?
-    connection = undefined
-    channel = undefined
-    emitter.emit('close', err)
-  }
+        if (!cb && typeof rpcOptions === 'const') {
 
-  function onDrain () {
-    setImmediate(function () {
-      publishing--
-      if (publishing === 0) {
-        emitter.emit('drain')
-      }
-    })
-  }
+            cb = rpcOptions;
+        }
 
-  function onChannel (err, chan) {
-    if (err) return bail(err)
-    channel = chan
-    channel.on('close', bail.bind(this, new Error('channel closed')))
-    channel.on('drain', onDrain)
-    emitter.emit('connected')
-    if (isDefault(emitter.name, emitter.type) || isNameless(emitter.name)) {
-      onExchange(undefined, {
-        exchange: emitter.name
-      })
-    } else {
-      channel.assertExchange(emitter.name, emitter.type, emitter.options, onExchange)
-    }
-  }
+        if (!rpcOptions || typeof rpcOptions !== 'object') {
+            rpcOptions = DEFAULT_RPC_CLIENT_OPTIONS;
+        }
 
-  function onExchange (err, info) {
-    if (err) return bail(err)
-    replyQueue.connect(connection)
-    replyQueue.once('ready', function () {
-      ready = true
-      emitter.emit('ready')
-    })
-  }
+        const opts = Extend({}, {
+            key,
+            rpcCallback: cb
+        }, rpcOptions);
 
-  function isDefault (name, type) {
-    return DEFAULT_EXCHANGES[type] === name
-  }
+        publish(msg, opts);
+    };
 
-  function isNameless (name) {
-    return name === ''
-  }
-}
+    const rpcServer = (key, handler) => {
+
+        const rpcQueue = createQueue({
+            key,
+            name: key,
+            prefetch: 1,
+            durable: false,
+            autoDelete: true
+        });
+        rpcQueue.consume(handler);
+    };
+
+    const connect = (con) => {
+
+        connection = con;
+        connection.createChannel(onChannel);
+        replyQueue.on('close', bail.bind(this));
+        replyQueue.consume(onReply, { noAck: true });
+        return emitter;
+    };
+
+    const createQueue = (queueOptions) => {
+
+        // return a promise when all keys are bound
+        const bindKeys = (keys) => {
+
+            // returns a promise when a key is bound
+            const bindKey = (key) => {
+
+                return new Promise(((resolve, reject) => {
+
+                    channel.bindQueue(newQueue.name, emitter.name, key, {}, (err, ok) => {
+
+                        if (err) {
+                            return reject(err);
+                        }
+
+                        return resolve(ok);
+                    });
+                }));
+            };
+
+            return Promise.all(keys.map(bindKey));
+        };
+
+        const newQueue = Queue(queueOptions);
+        newQueue.on('close', bail.bind(this));
+        newQueue.once('ready', () => {
+            // the default exchange has implicit bindings to all queues
+            if (!isNameless(emitter.name)) {
+                const keys = queueOptions.keys || [queueOptions.key];
+                bindKeys(keys)
+                    .then((res) => {
+
+                        newQueue.emit('bound');
+                    })
+                    .catch(bail);
+            }
+        });
+
+        if (connection) {
+            newQueue.connect(connection);
+        }
+        else {
+            emitter.once('ready', () => {
+
+                newQueue.connect(connection);
+            });
+        }
+
+        return newQueue;
+    };
+
+    const publish = (message, publishOptions) => {
+
+        const sendMessage = () => {
+            // TODO: better blacklisting/whitelisting of properties
+            const opts = Extend({}, DEFAULT_PUBLISH_OPTIONS, publishOptions);
+            const msg = encodeMessage(message, opts.contentType);
+
+            if (opts.reply) {
+                opts.replyTo = replyQueue.name;
+                opts.correlationId = Uuid();
+                pendingReplies[opts.correlationId] = opts.reply;
+                delete opts.reply;
+            }
+
+            const drained = channel.publish(emitter.name, opts.key, Buffer.from(msg), opts);
+            if (drained) {
+                onDrain();
+            }
+        };
+
+        const sendRpcMessage = () => {
+
+            const opts = Extend({}, DEFAULT_PUBLISH_OPTIONS, publishOptions);
+            const msg = encodeMessage(message, opts.contentType);
+
+            let replied = false;
+            const correlationId = Uuid();
+            const rpcCallback = opts.rpcCallback;
+
+            const onReply = (reply) => {
+
+                clearTimeout(timeout);
+                channel.removeListener('return', onNotFound);
+
+                if (!replied) {
+                    replied = true;
+                    rpcCallback(reply);
+                }
+            };
+
+            const onNotFound = (notFound) => {
+
+                clearTimeout(timeout);
+                clearPendingReply(correlationId);
+                channel.removeListener('return', onNotFound);
+
+                if (!replied) {
+                    replied = true;
+                    rpcCallback(new Error('Not Found'));
+                }
+            };
+
+            const timeout = setTimeout(() => {
+
+                clearPendingReply(correlationId);
+                channel.removeListener('return', onNotFound);
+
+                if (!replied) {
+                    replied = true;
+                    rpcCallback(new Error('Timeout'));
+                }
+            }, publishOptions.timeout || DEFAULT_RPC_CLIENT_OPTIONS.timeout);
+
+            opts.replyTo = replyQueue.name;
+            opts.correlationId = correlationId;
+            opts.mandatory = true;
+
+            pendingReplies[opts.correlationId] = onReply;
+            channel.once('return', onNotFound);
+
+            const drained = channel.publish(emitter.name, opts.key, Buffer.from(msg), opts);
+            if (drained) {
+                onDrain();
+            }
+        };
+
+        publishing++;
+        publishOptions = publishOptions || {};
+
+        const sendMessageRef = publishOptions.rpcCallback ? sendRpcMessage : sendMessage;
+
+        if (ready) {
+            sendMessageRef();
+        }
+        else {
+            emitter.once('ready', sendMessageRef);
+        }
+
+        return emitter;
+    };
+
+    const encodeMessage = (message, contentType) => {
+
+        if (contentType === 'application/json') {
+            return JSON.stringify(message);
+        }
+
+        return message;
+    };
+
+    const onReply = (data, ack, nack, msg) => {
+
+        const replyCallback = pendingReplies[msg.properties.correlationId];
+        if (replyCallback) {
+            replyCallback(data);
+        }
+
+        clearPendingReply(msg.properties.correlationId);
+    };
+
+    const clearPendingReply = (correlationId) => {
+
+        delete pendingReplies[correlationId];
+    };
+
+    const bail = (err) => {
+
+        // TODO: close all queue channels?
+        connection = undefined;
+        channel = undefined;
+        emitter.emit('close', err);
+    };
+
+    const onDrain = () => {
+
+        setImmediate(() => {
+
+            publishing--;
+            if (publishing === 0) {
+                emitter.emit('drain');
+            }
+        });
+    };
+
+    const onChannel = (err, chan) => {
+
+        if (err) {
+            return bail(err);
+        }
+
+        channel = chan;
+        channel.on('close', bail.bind(this, new Error('channel closed')));
+        channel.on('drain', onDrain);
+        emitter.emit('connected');
+        if (isDefault(emitter.name, DEFAULT_EXCHANGES[emitter.type]) || isNameless(emitter.name)) {
+            onExchange(undefined, {
+                exchange: emitter.name
+            });
+        }
+        else {
+            channel.assertExchange(emitter.name, emitter.type, emitter.options, onExchange);
+        }
+    };
+
+    const onExchange = (err, info) => {
+
+        if (err) {
+            return bail(err);
+        }
+
+        replyQueue.connect(connection);
+        replyQueue.once('ready', () => {
+
+            ready = true;
+            emitter.emit('ready');
+        });
+    };
+
+    const emitter = Extend(new EventEmitter(), {
+        name,
+        type,
+        options: Extend({}, DEFAULT_EXCHANGE_OPTIONS, options),
+        queue: createQueue,
+        connect,
+        publish,
+        rpcClient,
+        rpcServer
+    });
+
+    return emitter;
+};
+
+module.exports = exchange;

--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -58,7 +58,8 @@ const exchange = (name, type, options) => {
     }
 
     let ready = false;
-    let channel; let connection;
+    let channel;
+    let connection;
     let publishing = 0;
     const replyQueue = Queue({ exclusive: true });
     const pendingReplies = {};

--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -1,91 +1,117 @@
 'use strict';
 
-const amqp = require('amqplib/callback_api');
-const extend = require('lodash.assignin');
+const Amqp = require('amqplib/callback_api');
+const Extend = require('lodash.assignin');
 const EventEmitter = require('events').EventEmitter;
-const exchange = require('./exchange');
+const Exchange = require('./exchange');
+
+const jackrabbit = (url) => {
+
+    if (!url) {
+        throw new Error('url required for jackrabbit connection');
+    }
+
+    // public
+
+    const getInternals = () => {
+
+        return {
+            amqp: Amqp,
+            connection
+        };
+    };
+
+    const close = (callback) => {
+
+        if (!connection) {
+            if (callback) {
+                callback();
+            }
+
+            return;
+        }
+
+        try {
+            // I don't think amqplib should be throwing here, as this is an async const
+            // TODO: figure out how to test whether or not amqplib will throw
+            // (eg, how do they determine if closing is an illegal operation?)
+            connection.close((err) => {
+
+                if (callback) {
+                    callback(err);
+                }
+
+                rabbit.emit('close');
+            });
+        }
+        catch (e) {
+            if (callback) {
+                callback(e);
+            }
+        }
+    };
+
+    const createDefaultExchange = () => {
+
+        return createExchange()('direct', '');
+    };
+
+    const createExchange = () => {
+
+        return (type, name, options) => {
+
+            const newExchange = Exchange(name, type, options);
+            if (connection) {
+                newExchange.connect(connection);
+            }
+            else {
+                rabbit.once('connected', () => {
+
+                    newExchange.connect(connection);
+                });
+            }
+
+            return newExchange;
+        };
+    };
+
+    // private
+
+    const bail = (err) => {
+
+        // TODO close any connections or channels that remain open
+        connection = undefined;
+        if (err) {
+            rabbit.emit('error', err);
+        }
+    };
+
+    const onConnection = (err, conn) => {
+
+        if (err) {
+            return bail(err);
+        }
+
+        connection = conn;
+        connection.on('close', bail.bind(this));
+        rabbit.emit('connected');
+    };
+
+    // state
+    let connection;
+
+    const rabbit = Extend(new EventEmitter(), {
+        default: createDefaultExchange,
+        direct: createExchange().bind(null, 'direct'),
+        fanout: createExchange().bind(null, 'fanout'),
+        topic: createExchange().bind(null, 'topic'),
+        exchange: createExchange(),
+        close,
+        getInternals
+    });
+
+    Amqp.connect(url, onConnection);
+    return rabbit;
+};
 
 module.exports = jackrabbit;
-
-function jackrabbit(url) {
-  if (!url) throw new Error('url required for jackrabbit connection');
-
-  // state
-  let connection;
-
-  const rabbit = extend(new EventEmitter(), {
-    default: createDefaultExchange,
-    direct: createExchange().bind(null, 'direct'),
-    fanout: createExchange().bind(null, 'fanout'),
-    topic: createExchange().bind(null, 'topic'),
-    exchange: createExchange(),
-    close: close,
-    getInternals: getInternals
-  });
-
-  amqp.connect(url, onConnection);
-  return rabbit;
-
-  // public
-
-  function getInternals() {
-    return {
-      amqp: amqp,
-      connection: connection
-    };
-  }
-
-  function close(callback) {
-    if (!connection) {
-      if (callback) callback();
-      return;
-    }
-    try {
-      // I don't think amqplib should be throwing here, as this is an async function
-      // TODO: figure out how to test whether or not amqplib will throw
-      // (eg, how do they determine if closing is an illegal operation?)
-      connection.close(function(err) {
-        if (callback) callback(err);
-        rabbit.emit('close');
-      });
-    }
-    catch (e) {
-      if (callback) callback(e);
-    }
-  }
-
-  function createDefaultExchange() {
-    return createExchange()('direct', '');
-  }
-
-  function createExchange() {
-    return function(type, name, options) {
-      const newExchange = exchange(name, type, options);
-      if (connection) {
-        newExchange.connect(connection);
-      }
-      else {
-        rabbit.once('connected', function() {
-          newExchange.connect(connection);
-        });
-      }
-      return newExchange;
-    };
-  }
-
-  // private
-
-  function bail(err) {
-    // TODO close any connections or channels that remain open
-    connection = undefined;
-    channel = undefined;
-    if (err) rabbit.emit('error', err);
-  }
-
-  function onConnection(err, conn) {
-    if (err) return bail(err);
-    connection = conn;
-    connection.on('close', bail.bind(this));
-    rabbit.emit('connected');
-  }
-}

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,153 +1,191 @@
 'use strict';
 
-const amqp = require('amqplib/callback_api');
-const extend = require('lodash.assignin');
+const Extend = require('lodash.assignin');
 const EventEmitter = require('events').EventEmitter;
 
 const DEFAULT_QUEUE_OPTIONS = {
-  exclusive: false,
-  durable: true,
-  prefetch: 1,              // can be set on the queue because we use a per-queue channel
-  messageTtl: undefined,
-  maxLength: undefined
+    exclusive: false,
+    durable: true,
+    prefetch: 1,              // can be set on the queue because we use a per-queue channel
+    messageTtl: undefined,
+    maxLength: undefined
 };
 
 const DEFAULT_CONSUME_OPTIONS = {
-  consumerTag: undefined,
-  noAck: false,
-  exclusive: false,
-  priority: undefined
+    consumerTag: undefined,
+    noAck: false,
+    exclusive: false,
+    priority: undefined
+};
+
+const queue = (options) => {
+
+    const connect = (connection) => {
+
+        connection.createChannel(onChannel);
+    };
+
+    const consume = (callback, consumeOptions) => {
+
+        if ( ready ){
+            const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
+            channel.consume(emitter.name, onMessage, opts, onConsume);
+        }
+        else {
+            emitter.once('ready', () => {
+
+                const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
+                channel.consume(emitter.name, onMessage, opts, onConsume);
+            });
+        }
+
+        const onMessage = (msg) => {
+
+            const data = parseMessage(msg);
+            if (!data) {
+                return;
+            }
+
+            const ack = (reply) => {
+
+                const replyTo = msg.properties.replyTo;
+                const id = msg.properties.correlationId;
+                if (replyTo && id) {
+                    const buffer = encodeMessage(reply, msg.properties.contentType);
+                    channel.publish('', replyTo, buffer, {
+                        correlationId: id,
+                        contentType: msg.properties.contentType
+                    });
+                }
+
+                channel.ack(msg);
+            };
+
+            const nack = (opts) => {
+
+                opts = opts || {};
+                opts.allUpTo = opts.allUpTo !== undefined ? opts.allUpTo : false;
+                opts.requeue = opts.requeue !== undefined ? opts.requeue : true;
+                channel.nack(msg, opts.allUpTo, opts.requeue);
+            };
+
+            callback(data, ack, nack, msg);
+        };
+    };
+
+    const cancel = (done) => {
+
+        if (!consumerTag) {
+            return;
+        }
+
+        if (!channel) {
+            return;
+        }
+
+        channel.cancel(consumerTag, done);
+    };
+
+    const purge = (done) => {
+
+        const onPurged = (err, obj) => {
+
+            if (err) {
+                return done(err);
+            }
+
+            done(undefined, obj.messageCount);
+        };
+
+        if (channel) {
+            channel.purgeQueue(emitter.name, onPurged);
+        }
+        else {
+            emitter.once('ready', () => {
+
+                channel.purgeQueue(emitter.name, onPurged);
+            });
+        }
+    };
+
+    const encodeMessage = (message, contentType) => {
+
+        if (contentType === 'application/json') {
+            return Buffer.from(JSON.stringify(message));
+        }
+
+        return Buffer.from(message.toString());
+    };
+
+    const parseMessage = (msg) => {
+
+        if (msg.properties.contentType === 'application/json') {
+            try {
+                return JSON.parse(msg.content.toString());
+            }
+            catch (e) {
+                emitter.emit('error', new Error('unable to parse message as JSON'));
+                return;
+            }
+        }
+
+        return msg.content;
+    };
+
+    const onConsume = (err, info) => {
+
+        if (err) {
+            return bail(err);
+        }
+
+        consumerTag = info.consumerTag; // required to stop consuming
+        emitter.emit('consuming');
+    };
+
+    const bail = (err) => {
+    // TODO: close the channel if still open
+        channel = undefined;
+        emitter.name = undefined;
+        consumerTag = undefined;
+        emitter.emit('close', err);
+    };
+
+    const onChannel = (err, chan) => {
+
+        if (err) {
+            return bail(err);
+        }
+
+        channel = chan;
+        channel.prefetch(emitter.options.prefetch);
+        channel.on('close', bail.bind(this, new Error('channel closed')));
+        emitter.emit('connected');
+        channel.assertQueue(emitter.name, emitter.options, onQueue);
+    };
+
+    const onQueue = (err, info) => {
+
+        if (err) {
+            return bail(err);
+        }
+
+        emitter.name = info.queue;
+        ready = true;
+        emitter.emit('ready');
+    };
+
+    options = options || {};
+    let channel; let consumerTag; let ready;
+    const emitter = Extend(new EventEmitter(), {
+        name: options.name,
+        options: Extend({}, DEFAULT_QUEUE_OPTIONS, options),
+        connect,
+        consume,
+        cancel,
+        purge
+    });
+
+    return emitter;
 };
 
 module.exports = queue;
-
-function queue(options) {
-  options = options || {};
-  let channel, consumerTag, ready;
-  const emitter = extend(new EventEmitter(), {
-    name: options.name,
-    options: extend({}, DEFAULT_QUEUE_OPTIONS, options),
-    connect: connect,
-    consume: consume,
-    cancel: cancel,
-    purge: purge
-  });
-
-  return emitter;
-
-  function connect(connection) {
-    connection.createChannel(onChannel);
-  }
-
-  function consume(callback, options) {
-    if( ready ){
-      const opts = extend({}, DEFAULT_CONSUME_OPTIONS, options);
-      channel.consume(emitter.name, onMessage, opts, onConsume);
-    }
-
-    else {
-      emitter.once('ready', function() {
-        const opts = extend({}, DEFAULT_CONSUME_OPTIONS, options);
-        channel.consume(emitter.name, onMessage, opts, onConsume);
-      });
-    }
-
-    function onMessage(msg) {
-      const data = parseMessage(msg);
-      if (!data) return;
-
-      callback(data, ack, nack, msg);
-
-      function ack(reply) {
-        const replyTo = msg.properties.replyTo;
-        const id = msg.properties.correlationId;
-        if (replyTo && id) {
-          const buffer = encodeMessage(reply, msg.properties.contentType);
-          channel.publish('', replyTo, buffer, {
-            correlationId: id,
-            contentType: msg.properties.contentType
-          });
-        }
-        channel.ack(msg);
-      }
-
-      function nack(opts) {
-        opts = opts || {};
-        opts.allUpTo = opts.allUpTo !== undefined ? opts.allUpTo : false;
-        opts.requeue = opts.requeue !== undefined ? opts.requeue : true;
-        channel.nack(msg, opts.allUpTo, opts.requeue);
-      }
-    }
-  }
-
-  function cancel(done) {
-    if (!consumerTag) return;
-    if (!channel) return;
-    channel.cancel(consumerTag, done);
-  }
-
-  function purge(done) {
-    if (channel) {
-      channel.purgeQueue(emitter.name, onPurged);
-    } else {
-      emitter.once('ready', function() {
-        channel.purgeQueue(emitter.name, onPurged);
-      });
-    }
-
-    function onPurged(err, obj) {
-      if (err) return done(err);
-      done(undefined, obj.messageCount);
-    }
-  }
-
-  function encodeMessage(message, contentType) {
-    if (contentType === 'application/json') {
-      return new Buffer(JSON.stringify(message));
-    }
-    return new Buffer(message.toString());
-  }
-
-  function parseMessage(msg) {
-    if (msg.properties.contentType === 'application/json') {
-      try {
-        return JSON.parse(msg.content.toString());
-      }
-      catch (e) {
-        emitter.emit('error', new Error('unable to parse message as JSON'));
-        return;
-      }
-    }
-    return msg.content;
-  }
-
-  function onConsume(err, info) {
-    if (err) return bail(err);
-    consumerTag = info.consumerTag; // required to stop consuming
-    emitter.emit('consuming');
-  }
-
-  function bail(err) {
-    // TODO: close the channel if still open
-    channel = undefined;
-    emitter.name = undefined;
-    consumerTag = undefined;
-    emitter.emit('close', err);
-  }
-
-  function onChannel(err, chan) {
-    if (err) return bail(err);
-    channel = chan;
-    channel.prefetch(emitter.options.prefetch);
-    channel.on('close', bail.bind(this, new Error('channel closed')));
-    emitter.emit('connected');
-    channel.assertQueue(emitter.name, emitter.options, onQueue);
-  }
-
-  function onQueue(err, info) {
-    if (err) return bail(err);
-    emitter.name = info.queue;
-    ready = true;
-    emitter.emit('ready');
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,12 @@
         "url-parse": "~1.4.3"
       }
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
@@ -135,9 +141,9 @@
       }
     },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "buffer-more-ints": {
@@ -149,6 +155,12 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
     "chai": {
@@ -203,6 +215,34 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -217,15 +257,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
-    },
-    "commander": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-      "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true,
-      "requires": {
-        "graceful-readlink": ">= 1.0.0"
-      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -267,6 +298,12 @@
         "ms": "2.0.0"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -282,10 +319,19 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
     },
     "doctrine": {
@@ -302,6 +348,44 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "es-abstract": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -401,9 +485,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.0.0"
@@ -462,6 +546,21 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -509,6 +608,24 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -532,10 +649,22 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-func-name": {
@@ -543,6 +672,15 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "glob": {
       "version": "7.1.4",
@@ -573,16 +711,10 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
-    "graceful-readlink": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-      "dev": true
-    },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "hapi-capitalize-modules": {
@@ -609,16 +741,31 @@
       "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
       "dev": true
     },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "iconv-lite": {
@@ -688,6 +835,30 @@
         "through": "^2.3.6"
       }
     },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -714,6 +885,30 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "isarray": {
       "version": "0.0.1",
@@ -754,11 +949,14 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
-    "json3": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
-      "dev": true
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
     },
     "levn": {
       "version": "0.3.0",
@@ -770,44 +968,20 @@
         "type-check": "~0.3.2"
       }
     },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
-    },
-    "lodash._baseassign": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true,
-      "requires": {
-        "lodash._basecopy": "^3.0.0",
-        "lodash.keys": "^3.0.0"
-      }
-    },
-    "lodash._basecopy": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-      "dev": true
-    },
-    "lodash._basecreate": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
-      "dev": true
-    },
-    "lodash._getnative": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "dev": true
-    },
-    "lodash._isiterateecall": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
       "dev": true
     },
     "lodash.assignin": {
@@ -815,38 +989,41 @@
       "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
-    "lodash.create": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "^3.0.0",
-        "lodash._basecreate": "^3.0.0",
-        "lodash._isiterateecall": "^3.0.0"
+        "chalk": "^2.0.1"
       }
     },
-    "lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-      "dev": true
-    },
-    "lodash.isarray": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-      "dev": true
-    },
-    "lodash.keys": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
       "dev": true,
       "requires": {
-        "lodash._getnative": "^3.0.0",
-        "lodash.isarguments": "^3.0.0",
-        "lodash.isarray": "^3.0.0"
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+          "dev": true
+        }
       }
     },
     "mimic-fn": {
@@ -880,61 +1057,78 @@
       }
     },
     "mocha": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.9.0",
-        "debug": "2.6.8",
-        "diff": "3.2.0",
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.1",
-        "growl": "1.9.2",
-        "he": "1.1.1",
-        "json3": "3.3.2",
-        "lodash.create": "3.1.1",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "3.1.2"
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
         "glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
             "inherits": "2",
-            "minimatch": "^3.0.2",
+            "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         },
         "supports-color": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
           "dev": true,
           "requires": {
-            "has-flag": "^1.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -968,6 +1162,73 @@
       "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
       "dev": true
     },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1000,10 +1261,63 @@
         "wordwrap": "~1.0.0"
       }
     },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "parent-module": {
@@ -1014,6 +1328,12 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1045,6 +1365,16 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -1071,6 +1401,18 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "requires-port": {
@@ -1138,6 +1480,12 @@
       "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
       "dev": true
     },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -1197,6 +1545,26 @@
         }
       }
     },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -1218,6 +1586,12 @@
           "dev": true
         }
       }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "3.0.1",
@@ -1339,11 +1713,73 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1358,6 +1794,109 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/pagerinc/jackrabbit",
   "bugs": "https://github.com/pagerinc/jackrabbit/issues",
   "main": "lib/jackrabbit.js",
-  "scripts": {
+  "scripts": {  
     "test": "mocha",
     "lint": "eslint lib/** test/**"
   },
@@ -41,6 +41,7 @@
   },
   "mocha": {
     "bail": true,
+    "exit": true,
     "recursive": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,24 +19,28 @@
   "bugs": "https://github.com/pagerinc/jackrabbit/issues",
   "main": "lib/jackrabbit.js",
   "scripts": {
-    "test": "mocha -R spec",
-    "lint": "eslint ."
+    "test": "mocha",
+    "lint": "eslint lib/** test/**"
   },
   "engines": {
-    "node": ">= 0.10.x"
+    "node": ">= 10.x"
   },
   "author": "Hunter Loftis <hunter@hunterloftis.com>",
   "license": "MIT",
   "dependencies": {
-    "amqplib": "^0.5.1",
+    "amqplib": "0.5.x",
     "lodash.assignin": "4.x.x",
-    "uuid": "^3.0.1"
+    "uuid": "3.x.x"
   },
   "devDependencies": {
-    "chai": "4.x",
+    "chai": "4.x.x",
     "eslint": "6.x.x",
     "eslint-config-hapi": "12.x.x",
     "eslint-plugin-hapi": "4.x.x",
-    "mocha": "3.x.x"
+    "mocha": "6.x.x"
+  },
+  "mocha": {
+    "bail": true,
+    "recursive": true
   }
 }

--- a/test/env.js
+++ b/test/env.js
@@ -1,6 +1,6 @@
-'use strict'
+'use strict';
 
 // Loaded by Mocha. Enforces 'test' as the node environment.
 
-process.env.NODE_ENV = 'test'
-process.env.RABBIT_URL = 'amqp://localhost'
+process.env.NODE_ENV = 'test';
+process.env.RABBIT_URL = 'amqp://localhost';

--- a/test/env.js
+++ b/test/env.js
@@ -1,6 +1,0 @@
-'use strict';
-
-// Loaded by Mocha. Enforces 'test' as the node environment.
-
-process.env.NODE_ENV = 'test';
-process.env.RABBIT_URL = 'amqp://localhost';

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -1,118 +1,153 @@
-var assert = require('chai').assert;
-var amqp = require('amqplib/callback_api');
-var exchange = require('../lib/exchange');
-var uuid = require('uuid/v4');
+'use strict';
 
-describe('exchange', function() {
+const Assert = require('chai').assert;
+const Amqp = require('amqplib/callback_api');
+const Exchange = require('../lib/exchange');
+const Uuid = require('uuid/v4');
 
-  describe('constructor', function() {
+const { before, describe, it } = require('mocha');
 
-    describe("with empty name ('') and direct type", function() {
-      var e = exchange('', 'direct');
-      it('returns an exchange', function() {
-        assert.equal(e.name, '');
-        assert.equal(e.type, 'direct');
-        assert.ok(e.queue);
-        assert.ok(e.publish);
-      });
-    });
+describe('exchange', () => {
 
-    describe('with no name', function() {
+    describe('constructor', () => {
 
-      describe('and a direct type', function() {
-        var e = exchange(undefined, 'direct');
-        it('receives the default name amq.direct', function() {
-          assert.equal(e.name, 'amq.direct');
-        });
-      });
+        describe('with empty name (\'\') and direct type', () => {
 
-      describe('and a fanout type', function() {
-        var e = exchange(undefined, 'fanout');
-        it('receives the default name amq.fanout', function() {
-          assert.equal(e.name, 'amq.fanout');
-        });
-      });
+            const e = Exchange('', 'direct');
+            it('returns an exchange', () => {
 
-      describe('and a topic type', function() {
-        var e = exchange(undefined, 'topic');
-        it('receives the default name amq.topic', function() {
-          assert.equal(e.name, 'amq.topic');
-        });
-      });
-
-      describe('and no type', function() {
-        it('throws an error', function() {
-          assert.throws(exchange.bind(this, undefined, undefined), 'missing exchange type');
-        });
-      });
-    });
-  });
-
-  describe('#connect', function() {
-    before(function(done) {
-      amqp.connect(process.env.RABBIT_URL, function(err, conn) {
-        assert.ok(!err);
-        this.connection = conn;
-        done();
-      }.bind(this));
-    });
-    it('emits a "connected" event', function(done) {
-      exchange('', 'direct')
-        .connect(this.connection)
-        .once('connected', done);
-    });
-  });
-
-  describe('#queue', function() {
-    describe('with no options', function() {
-      before(function(done) {
-        amqp.connect(process.env.RABBIT_URL, function(err, conn) {
-          assert.ok(!err);
-          this.connection = conn;
-          done();
-        }.bind(this));
-      });
-      before(function() {
-        this.q = exchange('', 'direct')
-          .connect(this.connection)
-          .queue();
-      });
-      it('returns a queue instance', function() {
-        assert.ok(this.q.consume);
-      });
-    });
-
-    describe('with key bindings', function () {
-      before(function(done) {
-        amqp.connect(process.env.RABBIT_URL, function(err, conn) {
-          assert.ok(!err);
-          this.exchange = exchange('test.topic.bindings', 'topic')
-            .connect(conn)
-            .once('connected', done);
-        }.bind(this));
-      });
-
-      it('emits a "bound" event when all routing keys have been bound to the queue', function (done) {
-        var keys = 'abcdefghijklmnopqrstuvwxyz'.split('');
-        var finalKey = keys[keys.length - 1];
-        var queue = this.exchange.queue({ keys: keys });
-        var message = uuid();
-
-        queue.consume(function (data, ack, nack, msg) {
-          assert.equal(message, data);
-          assert.equal(msg.fields.routingKey, finalKey);
-          ack();
-          done();
+                Assert.equal(e.name, '');
+                Assert.equal(e.type, 'direct');
+                Assert.ok(e.queue);
+                Assert.ok(e.publish);
+            });
         });
 
-        queue.once('bound', function () {
-          this.exchange.publish(message, { key: finalKey });
-        }.bind(this));
-      });
+        describe('with no name', () => {
+
+            describe('and a direct type', () => {
+
+                const e = Exchange(undefined, 'direct');
+                it('receives the default name amq.direct', () => {
+
+                    Assert.equal(e.name, 'amq.direct');
+                });
+            });
+
+            describe('and a fanout type', () => {
+
+                const e = Exchange(undefined, 'fanout');
+                it('receives the default name amq.fanout', () => {
+
+                    Assert.equal(e.name, 'amq.fanout');
+                });
+            });
+
+            describe('and a topic type', () => {
+
+                const e = Exchange(undefined, 'topic');
+                it('receives the default name amq.topic', () => {
+
+                    Assert.equal(e.name, 'amq.topic');
+                });
+            });
+
+            describe('and no type', () => {
+
+                it('throws an error', () => {
+
+                    Assert.throws(Exchange.bind(this, undefined, undefined), 'missing exchange type');
+                });
+            });
+        });
     });
-  });
 
-  describe('#publish', function() {
+    describe('#connect', () => {
 
-  });
+        before((done) => {
+
+            Amqp.connect(process.env.RABBIT_URL, (err, conn) => {
+
+                Assert.ok(!err);
+                this.connection = conn;
+                done();
+            });
+        });
+
+        it('emits a "connected" event', (done) => {
+
+            Exchange('', 'direct')
+                .connect(this.connection)
+                .once('connected', done);
+        });
+    });
+
+    describe('#queue', () => {
+
+        describe('with no options', () => {
+
+            before((done) => {
+
+                Amqp.connect(process.env.RABBIT_URL, (err, conn) => {
+
+                    Assert.ok(!err);
+                    this.connection = conn;
+                    done();
+                });
+            });
+
+            before(() => {
+
+                this.q = Exchange('', 'direct')
+                    .connect(this.connection)
+                    .queue();
+            });
+
+            it('returns a queue instance', () => {
+
+                Assert.ok(this.q.consume);
+            });
+        });
+
+        describe('with key bindings', () => {
+
+            before((done) => {
+
+                const connect = (err, conn) => {
+
+                    Assert.ok(!err);
+                    this.exchange = Exchange('test.topic.bindings', 'topic')
+                        .connect(conn)
+                        .once('connected', done);
+                };
+
+                Amqp.connect(process.env.RABBIT_URL, connect.bind(this));
+            });
+
+            it('emits a "bound" event when all routing keys have been bound to the queue', (done) => {
+
+                const keys = 'abcdefghijklmnopqrstuvwxyz'.split('');
+                const finalKey = keys[keys.length - 1];
+                const queue = this.exchange.queue({ keys });
+                const message = Uuid();
+
+                queue.consume((data, ack, nack, msg) => {
+
+                    Assert.equal(message, data);
+                    Assert.equal(msg.fields.routingKey, finalKey);
+                    ack();
+                    done();
+                });
+
+                queue.once('bound', () => {
+
+                    this.exchange.publish(message, { key: finalKey });
+                });
+            });
+        });
+    });
+
+    describe('#publish', () => {
+
+    });
 });

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -5,7 +5,7 @@ const Amqp = require('amqplib/callback_api');
 const Exchange = require('../lib/exchange');
 const Uuid = require('uuid/v4');
 
-const { before, describe, it } = require('mocha');
+const { after, before, describe, it } = require('mocha');
 
 describe('exchange', () => {
 
@@ -80,6 +80,11 @@ describe('exchange', () => {
                 .connect(this.connection)
                 .once('connected', done);
         });
+
+        after((done) => {
+
+            this.connection.close(done);
+        });
     });
 
     describe('#queue', () => {
@@ -92,20 +97,21 @@ describe('exchange', () => {
 
                     Assert.ok(!err);
                     this.connection = conn;
+                    this.q = Exchange('', 'direct')
+                        .connect(this.connection)
+                        .queue();
                     done();
                 });
-            });
-
-            before(() => {
-
-                this.q = Exchange('', 'direct')
-                    .connect(this.connection)
-                    .queue();
             });
 
             it('returns a queue instance', () => {
 
                 Assert.ok(this.q.consume);
+            });
+
+            after((done) => {
+
+                this.connection.close(done);
             });
         });
 
@@ -116,6 +122,7 @@ describe('exchange', () => {
                 const connect = (err, conn) => {
 
                     Assert.ok(!err);
+                    this.connection = conn;
                     this.exchange = Exchange('test.topic.bindings', 'topic')
                         .connect(conn)
                         .once('connected', done);
@@ -144,10 +151,11 @@ describe('exchange', () => {
                     this.exchange.publish(message, { key: finalKey });
                 });
             });
+
+            after((done) => {
+
+                this.connection.close(done);
+            });
         });
-    });
-
-    describe('#publish', () => {
-
     });
 });

--- a/test/jackrabbit.test.js
+++ b/test/jackrabbit.test.js
@@ -1,181 +1,255 @@
-var assert = require('chai').assert;
-var jackrabbit = require('../lib/jackrabbit');
+'use strict';
 
-describe('jackrabbit', function(){
+const Assert = require('chai').assert;
+const Jackrabbit = require('../lib/jackrabbit');
 
-  describe('constructor', function() {
-    describe('with a valid server url', function() {
-      it('emits a "connected" event', function(done) {
-        this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
-      });
-      it('references a Connection object', function() {
-        var c = this.r.getInternals().connection;
-        assert.ok(c.connection.stream.writable);
-      });
-    });
-    describe('without a server url', function() {
-      it('throws a "url required" error', function() {
-        assert.throws(jackrabbit, 'url required');
-      });
-    });
-    // describe('with an invalid url', function() {
-    //   it('emits an "error" event', function(done) {
-    //     jackrabbit('amqp://1.2')
-    //       .once('error', function(err) {
-    //         assert.ok(err);
-    //         done();
-    //       });
-    //   });
-    // });
-  });
+const { before, describe, it } = require('mocha');
 
-  describe('#default', function() {
-    describe('without a "name" argument', function() {
-      before(function() {
-        var r = jackrabbit(process.env.RABBIT_URL);
-        this.e = r.default();
-      });
-      it('returns a direct, nameless exchange', function() {
-        assert.ok(this.e.queue);
-        assert.ok(this.e.publish);
-        assert.equal(this.e.type, 'direct');
-        assert.equal(this.e.name, '');
-      });
-    });
-    describe('with a "name" argument', function() {
-      before(function() {
-        var r = jackrabbit(process.env.RABBIT_URL);
-        this.e = r.default('foobar');
-      });
-      it('returns a direct, nameless exchange', function() {
-        assert.ok(this.e.queue);
-        assert.ok(this.e.publish);
-        assert.equal(this.e.type, 'direct');
-        assert.equal(this.e.name, '');
-      });
-    });
-    describe('before connection is established', function() {
-      it('passes the connection to the exchange', function(done) {
-        jackrabbit(process.env.RABBIT_URL)
-          .default()
-          .once('connected', done);
-      })
-    });
-    describe('after connection is established', function() {
-      before(function(done) {
-        this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
-      });
-      it('passes the connection to the exchange', function(done) {
-        this.r
-          .default()
-          .once('connected', done);
-      });
-    });
-  });
+describe('jackrabbit', () => {
 
-  describe('#direct', function() {
-    describe('without a "name" argument', function() {
-      before(function() {
-        var r = jackrabbit(process.env.RABBIT_URL);
-        this.e = r.direct();
-      });
-      it('returns the direct exchange named "amq.direct"', function() {
-        assert.ok(this.e.queue);
-        assert.ok(this.e.publish);
-        assert.equal(this.e.type, 'direct');
-        assert.equal(this.e.name, 'amq.direct');
-      });
-    });
-    describe('with a "name" argument of "foobar.direct"', function() {
-      before(function() {
-        var r = jackrabbit(process.env.RABBIT_URL);
-        this.e = r.direct('foobar.direct');
-      });
-      it('returns a direct exchange named "foobar.direct"', function() {
-        assert.ok(this.e.queue);
-        assert.ok(this.e.publish);
-        assert.equal(this.e.type, 'direct');
-        assert.equal(this.e.name, 'foobar.direct');
-      });
-    });
-    describe('before connection is established', function() {
-      it('passes the connection to the exchange', function(done) {
-        jackrabbit(process.env.RABBIT_URL)
-          .direct()
-          .once('connected', done);
-      })
-    });
-    describe('after connection is established', function() {
-      before(function(done) {
-        this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
-      });
-      it('passes the connection to the exchange', function(done) {
-        this.r
-          .direct()
-          .once('connected', done);
-      });
-    });
-  });
+    describe('constructor', () => {
 
-  describe('#fanout', function() {
-    describe('without a "name" argument', function() {
-      before(function() {
-        var r = jackrabbit(process.env.RABBIT_URL);
-        this.e = r.fanout();
-      });
-      it('returns the direct exchange named "amq.fanout"', function() {
-        assert.ok(this.e.queue);
-        assert.ok(this.e.publish);
-        assert.equal(this.e.type, 'fanout');
-        assert.equal(this.e.name, 'amq.fanout');
-      });
-    });
-    describe('with a "name" argument of "foobar.fanout"', function() {
-      before(function() {
-        var r = jackrabbit(process.env.RABBIT_URL);
-        this.e = r.fanout('foobar.fanout');
-      });
-      it('returns a direct exchange named "foobar.fanout"', function() {
-        assert.ok(this.e.queue);
-        assert.ok(this.e.publish);
-        assert.equal(this.e.type, 'fanout');
-        assert.equal(this.e.name, 'foobar.fanout');
-      });
-    });
-    describe('before connection is established', function() {
-      it('passes the connection to the exchange', function(done) {
-        jackrabbit(process.env.RABBIT_URL)
-          .fanout()
-          .once('connected', done);
-      })
-    });
-    describe('after connection is established', function() {
-      before(function(done) {
-        this.r = jackrabbit(process.env.RABBIT_URL);
-        this.r.once('connected', done);
-      });
-      it('passes the connection to the exchange', function(done) {
-        this.r
-          .fanout()
-          .once('connected', done);
-      });
-    });
-  });
+        describe('with a valid server url', () => {
 
-  describe('#close', function() {
-    before(function(done) {
-      this.r = jackrabbit(process.env.RABBIT_URL);
-      this.r.once('connected', done);
+            it('emits a "connected" event', (done) => {
+
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.r.once('connected', done);
+            });
+
+            it('references a Connection object', () => {
+
+                const c = this.r.getInternals().connection;
+                Assert.ok(c.connection.stream.writable);
+            });
+        });
+
+        describe('without a server url', () => {
+
+            it('throws a "url required" error', () => {
+
+                Assert.throws(Jackrabbit, 'url required');
+            });
+        });
+
+        // describe('with an invalid url', () => {
+        //   it('emits an "error" event', (done) => {
+        //     jackrabbit('amqp://1.2')
+        //       .once('error', function(err) {
+        //         assert.ok(err);
+        //         done();
+        //       });
+        //   });
+        // });
+
     });
-    it('emits a "close" event', function(done) {
-      this.r.close();
-      this.r.once('close', done);
+
+    describe('#default', () => {
+
+        describe('without a "name" argument', () => {
+
+            before(() => {
+
+                const r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = r.default();
+            });
+
+            it('returns a direct, nameless exchange', () => {
+
+                Assert.ok(this.e.queue);
+                Assert.ok(this.e.publish);
+                Assert.equal(this.e.type, 'direct');
+                Assert.equal(this.e.name, '');
+            });
+        });
+
+        describe('with a "name" argument', () => {
+
+            before(() => {
+
+                const r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = r.default('foobar');
+            });
+
+            it('returns a direct, nameless exchange', () => {
+
+                Assert.ok(this.e.queue);
+                Assert.ok(this.e.publish);
+                Assert.equal(this.e.type, 'direct');
+                Assert.equal(this.e.name, '');
+            });
+        });
+
+        describe('before connection is established', () => {
+
+            it('passes the connection to the exchange', (done) => {
+
+                Jackrabbit(process.env.RABBIT_URL)
+                    .default()
+                    .once('connected', done);
+            });
+        });
+
+        describe('after connection is established', () => {
+
+            before((done) => {
+
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.r.once('connected', done);
+            });
+
+            it('passes the connection to the exchange', (done) => {
+
+                this.r
+                    .default()
+                    .once('connected', done);
+            });
+        });
     });
-    it('clears the connection', function() {
-      assert.ok(!this.r.getInternals().connection);
+
+    describe('#direct', () => {
+
+        describe('without a "name" argument', () => {
+
+            before(() => {
+
+                const r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = r.direct();
+            });
+
+            it('returns the direct exchange named "amq.direct"', () => {
+
+                Assert.ok(this.e.queue);
+                Assert.ok(this.e.publish);
+                Assert.equal(this.e.type, 'direct');
+                Assert.equal(this.e.name, 'amq.direct');
+            });
+        });
+
+        describe('with a "name" argument of "foobar.direct"', () => {
+
+            before(() => {
+
+                const r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = r.direct('foobar.direct');
+            });
+
+            it('returns a direct exchange named "foobar.direct"', () => {
+
+                Assert.ok(this.e.queue);
+                Assert.ok(this.e.publish);
+                Assert.equal(this.e.type, 'direct');
+                Assert.equal(this.e.name, 'foobar.direct');
+            });
+        });
+
+        describe('before connection is established', () => {
+
+            it('passes the connection to the exchange', (done) => {
+
+                Jackrabbit(process.env.RABBIT_URL)
+                    .direct()
+                    .once('connected', done);
+            });
+        });
+
+        describe('after connection is established', () => {
+
+            before((done) => {
+
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.r.once('connected', done);
+            });
+
+            it('passes the connection to the exchange', (done) => {
+
+                this.r
+                    .direct()
+                    .once('connected', done);
+            });
+        });
     });
-  });
+
+    describe('#fanout', () => {
+
+        describe('without a "name" argument', () => {
+
+            before(() => {
+
+                const r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = r.fanout();
+            });
+
+            it('returns the direct exchange named "amq.fanout"', () => {
+
+                Assert.ok(this.e.queue);
+                Assert.ok(this.e.publish);
+                Assert.equal(this.e.type, 'fanout');
+                Assert.equal(this.e.name, 'amq.fanout');
+            });
+        });
+
+        describe('with a "name" argument of "foobar.fanout"', () => {
+
+            before(() => {
+
+                const r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = r.fanout('foobar.fanout');
+            });
+
+            it('returns a direct exchange named "foobar.fanout"', () => {
+
+                Assert.ok(this.e.queue);
+                Assert.ok(this.e.publish);
+                Assert.equal(this.e.type, 'fanout');
+                Assert.equal(this.e.name, 'foobar.fanout');
+            });
+        });
+
+        describe('before connection is established', () => {
+
+            it('passes the connection to the exchange', (done) => {
+
+                Jackrabbit(process.env.RABBIT_URL)
+                    .fanout()
+                    .once('connected', done);
+            });
+        });
+
+        describe('after connection is established', () => {
+
+            before((done) => {
+
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.r.once('connected', done);
+            });
+
+            it('passes the connection to the exchange', (done) => {
+
+                this.r
+                    .fanout()
+                    .once('connected', done);
+            });
+        });
+    });
+
+    describe('#close', () => {
+
+        before((done) => {
+
+            this.r = Jackrabbit(process.env.RABBIT_URL);
+            this.r.once('connected', done);
+        });
+
+        it('emits a "close" event', (done) => {
+
+            this.r.close();
+            this.r.once('close', done);
+        });
+
+        it('clears the connection', () => {
+
+            Assert.ok(!this.r.getInternals().connection);
+        });
+    });
 });

--- a/test/jackrabbit.test.js
+++ b/test/jackrabbit.test.js
@@ -3,7 +3,7 @@
 const Assert = require('chai').assert;
 const Jackrabbit = require('../lib/jackrabbit');
 
-const { before, describe, it } = require('mocha');
+const { after, before, describe, it } = require('mocha');
 
 describe('jackrabbit', () => {
 
@@ -11,9 +11,13 @@ describe('jackrabbit', () => {
 
         describe('with a valid server url', () => {
 
-            it('emits a "connected" event', (done) => {
+            before(() => {
 
                 this.r = Jackrabbit(process.env.RABBIT_URL);
+            });
+
+            it('emits a "connected" event', (done) => {
+
                 this.r.once('connected', done);
             });
 
@@ -21,6 +25,11 @@ describe('jackrabbit', () => {
 
                 const c = this.r.getInternals().connection;
                 Assert.ok(c.connection.stream.writable);
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
 
@@ -50,8 +59,8 @@ describe('jackrabbit', () => {
 
             before(() => {
 
-                const r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = r.default();
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = this.r.default();
             });
 
             it('returns a direct, nameless exchange', () => {
@@ -60,6 +69,11 @@ describe('jackrabbit', () => {
                 Assert.ok(this.e.publish);
                 Assert.equal(this.e.type, 'direct');
                 Assert.equal(this.e.name, '');
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
 
@@ -67,8 +81,8 @@ describe('jackrabbit', () => {
 
             before(() => {
 
-                const r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = r.default('foobar');
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = this.r.default('foobar');
             });
 
             it('returns a direct, nameless exchange', () => {
@@ -78,15 +92,30 @@ describe('jackrabbit', () => {
                 Assert.equal(this.e.type, 'direct');
                 Assert.equal(this.e.name, '');
             });
+
+            after((done) => {
+
+                this.r.close(done);
+            });
         });
 
         describe('before connection is established', () => {
 
+            before(() => {
+
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+            });
+
             it('passes the connection to the exchange', (done) => {
 
-                Jackrabbit(process.env.RABBIT_URL)
+                this.r
                     .default()
                     .once('connected', done);
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
 
@@ -103,6 +132,11 @@ describe('jackrabbit', () => {
                 this.r
                     .default()
                     .once('connected', done);
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
     });
@@ -113,8 +147,8 @@ describe('jackrabbit', () => {
 
             before(() => {
 
-                const r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = r.direct();
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = this.r.direct();
             });
 
             it('returns the direct exchange named "amq.direct"', () => {
@@ -124,14 +158,19 @@ describe('jackrabbit', () => {
                 Assert.equal(this.e.type, 'direct');
                 Assert.equal(this.e.name, 'amq.direct');
             });
+
+            after((done) => {
+
+                this.r.close(done);
+            });
         });
 
         describe('with a "name" argument of "foobar.direct"', () => {
 
             before(() => {
 
-                const r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = r.direct('foobar.direct');
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = this.r.direct('foobar.direct');
             });
 
             it('returns a direct exchange named "foobar.direct"', () => {
@@ -141,15 +180,30 @@ describe('jackrabbit', () => {
                 Assert.equal(this.e.type, 'direct');
                 Assert.equal(this.e.name, 'foobar.direct');
             });
+
+            after((done) => {
+
+                this.r.close(done);
+            });
         });
 
         describe('before connection is established', () => {
 
+            before(() => {
+
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+            });
+
             it('passes the connection to the exchange', (done) => {
 
-                Jackrabbit(process.env.RABBIT_URL)
+                this.r
                     .direct()
                     .once('connected', done);
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
 
@@ -166,6 +220,11 @@ describe('jackrabbit', () => {
                 this.r
                     .direct()
                     .once('connected', done);
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
     });
@@ -176,8 +235,8 @@ describe('jackrabbit', () => {
 
             before(() => {
 
-                const r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = r.fanout();
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = this.r.fanout();
             });
 
             it('returns the direct exchange named "amq.fanout"', () => {
@@ -187,14 +246,19 @@ describe('jackrabbit', () => {
                 Assert.equal(this.e.type, 'fanout');
                 Assert.equal(this.e.name, 'amq.fanout');
             });
+
+            after((done) => {
+
+                this.r.close(done);
+            });
         });
 
         describe('with a "name" argument of "foobar.fanout"', () => {
 
             before(() => {
 
-                const r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = r.fanout('foobar.fanout');
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+                this.e = this.r.fanout('foobar.fanout');
             });
 
             it('returns a direct exchange named "foobar.fanout"', () => {
@@ -204,15 +268,31 @@ describe('jackrabbit', () => {
                 Assert.equal(this.e.type, 'fanout');
                 Assert.equal(this.e.name, 'foobar.fanout');
             });
+
+            after((done) => {
+
+                this.r.close(done);
+            });
         });
 
         describe('before connection is established', () => {
 
+
+            before(() => {
+
+                this.r = Jackrabbit(process.env.RABBIT_URL);
+            });
+
             it('passes the connection to the exchange', (done) => {
 
-                Jackrabbit(process.env.RABBIT_URL)
+                this.r
                     .fanout()
                     .once('connected', done);
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
 
@@ -229,6 +309,11 @@ describe('jackrabbit', () => {
                 this.r
                     .fanout()
                     .once('connected', done);
+            });
+
+            after((done) => {
+
+                this.r.close(done);
             });
         });
     });
@@ -243,13 +328,18 @@ describe('jackrabbit', () => {
 
         it('emits a "close" event', (done) => {
 
-            this.r.close();
             this.r.once('close', done);
+            this.r.close();
         });
 
         it('clears the connection', () => {
 
             Assert.ok(!this.r.getInternals().connection);
+        });
+
+        after((done) => {
+
+            this.r.close(done);
         });
     });
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,0 @@
---reporter spec
---ui bdd
---recursive
---bail
---require test/env

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -1,114 +1,137 @@
-var assert = require('chai').assert;
-var amqp = require('amqplib/callback_api');
-var uuid = require('uuid/v4');
-var exchange = require('../lib/exchange');
-var queue = require('../lib/queue');
+'use strict';
 
-describe('queue', function() {
+const Assert = require('chai').assert;
+const Amqp = require('amqplib/callback_api');
+const Uuid = require('uuid/v4');
+const Exchange = require('../lib/exchange');
+const Queue = require('../lib/queue');
 
-  describe('consume', function() {
+const { describe, before, it } = require('mocha');
 
-    before(createConnection);
+const createConnection = (done) => {
 
-    before(function() {
-      this.name = `test.queue.consume.${ uuid() }`;
-      this.exchange = exchange('', 'direct')
-      this.exchange.connect(this.connection);
-      this.queue = queue({ name: this.name });
-      this.queue.connect(this.connection);
-    })
+    const connect = (err, conn) => {
 
-    it('calls the message handler when a message arrives', function(done) {
-      var message = uuid();
-      var n = 3;
-      var received = 0;
-
-      this.queue.consume(onMessage, { noAck: true });
-
-      for (var i = 0; i < n; i++) {
-        this.exchange.publish(message, { key: this.name });
-      }
-
-      function onMessage(data, ack, nack, msg) {
-        assert.equal(data, message);
-        received++;
-        if (received === n) done();
-      }
-    });
-  });
-
-  describe('cancel', function() {
-
-    before(createConnection);
-
-    before(function() {
-      this.name = `test.queue.cancel.${ uuid() }`;
-      this.exchange = exchange('', 'direct')
-      this.exchange.connect(this.connection);
-      this.queue = queue({ name: this.name });
-      this.queue.connect(this.connection);
-    });
-
-    it('initially consumes messages', function(done) {
-      var message = uuid();
-
-      this.queue.consume(onMessage, { noAck: true });
-      this.exchange.publish(message, { key: this.name });
-
-      function onMessage(data, ack, nack, msg) {
-        assert.equal(data, message);
+        Assert.ok(!err);
+        this.connection = conn;
         done();
-      }
+    };
+
+    Amqp.connect(process.env.RABBIT_URL, connect.bind(this));
+};
+
+describe('queue', () => {
+
+    describe('consume', () => {
+
+        before(createConnection);
+
+        before(() => {
+
+            this.name = `test.queue.consume.${ Uuid() }`;
+            this.exchange = Exchange('', 'direct');
+            this.exchange.connect(this.connection);
+            this.queue = Queue({ name: this.name });
+            this.queue.connect(this.connection);
+        });
+
+        it('calls the message handler when a message arrives', (done) => {
+
+            const onMessage = (data, ack, nack, msg) => {
+
+                Assert.equal(data, message);
+                received++;
+                if (received === n) {
+                    done();
+                }
+            };
+
+            const message = Uuid();
+            const n = 3;
+            let received = 0;
+
+            this.queue.consume(onMessage, { noAck: true });
+
+            for (let i = 0; i < n; ++i) {
+                this.exchange.publish(message, { key: this.name });
+            }
+        });
     });
 
-    it('calls back with ok', function(done) {
-      this.queue.cancel(done);
+    describe('cancel', () => {
+
+        before(createConnection);
+
+        before(() => {
+
+            this.name = `test.queue.cancel.${ Uuid() }`;
+            this.exchange = Exchange('', 'direct');
+            this.exchange.connect(this.connection);
+            this.queue = Queue({ name: this.name });
+            this.queue.connect(this.connection);
+        });
+
+        it('initially consumes messages', (done) => {
+
+            const onMessage = (data, ack, nack, msg) => {
+
+                Assert.equal(data, message);
+                done();
+            };
+
+            const message = Uuid();
+
+            this.queue.consume(onMessage, { noAck: true });
+            this.exchange.publish(message, { key: this.name });
+        });
+
+        it('calls back with ok', (done) => {
+
+            this.queue.cancel(done);
+        });
+
+        it('stops consuming after cancel', (done) => {
+
+            this.exchange.publish('should not consume', {
+                key: this.name,
+                noAck: true
+            });
+
+            setTimeout(done, 250);
+        });
+
     });
 
-    it('stops consuming after cancel', function(done) {
-      this.exchange.publish('should not consume', {
-        key: this.name,
-        noAck: true
-      });
+    describe('purge', () => {
 
-      setTimeout(done, 250);
+        before(createConnection);
+
+        before(() => {
+
+            this.name = `test.queue.purge.${ Uuid() }`;
+            this.exchange = Exchange('', 'direct');
+            this.exchange.connect(this.connection);
+            this.queue = Queue({ name: this.name });
+            this.queue.connect(this.connection);
+        });
+
+        before((done) => {
+
+            let n = 10;
+            while (n--) {
+                this.exchange.publish('test', { key: this.name });
+            }
+
+            setTimeout(done, 100);
+        });
+
+        it('returns the number of messages purged', (done) => {
+
+            this.queue.purge((err, count) => {
+
+                Assert.ok(count > 5);
+                done(err);
+            });
+        });
     });
-
-  });
-
-  describe('purge', function() {
-
-    before(createConnection);
-
-    before(function() {
-      this.name = `test.queue.purge.${ uuid() }`;
-      this.exchange = exchange('', 'direct')
-      this.exchange.connect(this.connection);
-      this.queue = queue({ name: this.name });
-      this.queue.connect(this.connection);
-    });
-
-    before(function(done) {
-      var n = 10;
-      while(n--) {
-        this.exchange.publish('test', { key: this.name });
-      }
-      setTimeout(done, 100);
-    });
-
-    it('returns the number of messages purged', function(done) {
-      this.queue.purge(function(err, count) {
-        assert.ok(count > 5);
-        done(err);
-      });
-    });
-  });
 });
-
-function createConnection(done) {
-  amqp.connect(process.env.RABBIT_URL, function(err, conn) {
-    assert.ok(!err);
-    this.connection = conn;
-    done();
-  }.bind(this));
-}

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -6,7 +6,7 @@ const Uuid = require('uuid/v4');
 const Exchange = require('../lib/exchange');
 const Queue = require('../lib/queue');
 
-const { describe, before, it } = require('mocha');
+const { after, before, describe, it } = require('mocha');
 
 const createConnection = (done) => {
 
@@ -56,6 +56,11 @@ describe('queue', () => {
                 this.exchange.publish(message, { key: this.name });
             }
         });
+
+        after((done) => {
+
+            this.connection.close(done);
+        });
     });
 
     describe('cancel', () => {
@@ -100,6 +105,10 @@ describe('queue', () => {
             setTimeout(done, 250);
         });
 
+        after((done) => {
+
+            this.connection.close(done);
+        });
     });
 
     describe('purge', () => {
@@ -132,6 +141,11 @@ describe('queue', () => {
                 Assert.ok(count > 5);
                 done(err);
             });
+        });
+
+        after((done) => {
+
+            this.connection.close(done);
         });
     });
 });


### PR DESCRIPTION
This change is massive but no functional changes were made. All same 30 tests still run and pass the summary of changes follows:

- Implement lint and run in CI - this is 99% of this PR (indentation, following hapi style guidelines, arrow functions, etc)
- Upgrading to mocha 6
- removing `mocha.opts` in lieu of package.json config as suggested by mocha
- Upgrading supported node version to `>= 10.x`
- Bump circle ci node image pin to latest sha