### PR TITLE
feat: add dockerfile, bump amqplib, clean up package.json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: ~/repo
   docker:
-  - image: circleci/node:10.16@sha256:f2d92d07c935105ed17f15620694e921b9b88cd7f698ed4d64e28925da3cbee0
+  - image: circleci/node:10.16@sha256:e8367bd0ac98ec9b13baaf700321e9a1796c1c255c9b7953da1dda1f07aeb0ed
   - image: rabbitmq:3.7-alpine@sha256:e07eb197eb8d60e1cf5541b5e3eb6230a1010577aa5b06670af5be55eba47b74
 
 jobs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:10.16-alpine@sha256:77c898d0da5e7bfb6e05c9a64de136ba4e03889a72f3c298e95df822a38f450d
+
+RUN apk add --no-cache tini
+
+ENTRYPOINT ["/sbin/tini", "--"]
+
+WORKDIR /home/node/app
+
+COPY package.json package-lock.json /home/node/app/
+
+RUN chown -R node /home/node && \
+	apk add --no-cache --virtual .build-deps && \
+	npm install --quiet && \
+	npm cache clean --force && \
+	apk del .build-deps
+
+COPY . /home/node/app
+
+USER node
+
+CMD ["npm", "test"]

--- a/README.md
+++ b/README.md
@@ -75,13 +75,5 @@ so you don't need to install rabbitmq (or even node)
 to run them:
 
 ```
-$ docker-compose run jackrabbit npm test
-```
-
-If using Docker-Machine on OSX:
-
-```
-$ docker-machine start
-$ eval "$(docker-machine env default)"
-$ docker-compose run jackrabbit npm test
+$ docker-compose up
 ```

--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -11,6 +11,10 @@ const jackrabbit = (url) => {
         throw new Error('url required for jackrabbit connection');
     }
 
+    // state
+
+    let connection;
+
     // public
 
     const getInternals = () => {
@@ -96,9 +100,6 @@ const jackrabbit = (url) => {
         connection.on('close', bail.bind(this));
         rabbit.emit('connected');
     };
-
-    // state
-    let connection;
 
     const rabbit = Extend(new EventEmitter(), {
         default: createDefaultExchange,

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
       }
     },
     "amqplib": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.3.tgz",
-      "integrity": "sha512-ZOdUhMxcF+u62rPI+hMtU1NBXSDFQ3eCJJrenamtdQ7YYwh7RZJHOIM1gonVbZ5PyVdYH4xqBPje9OYqk7fnqw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.5.5.tgz",
+      "integrity": "sha512-sWx1hbfHbyKMw6bXOK2k6+lHL8TESWxjAx5hG8fBtT7wcxoXNIsFxZMnFyBjxt3yL14vn7WqBDe5U6BGOadtLg==",
       "requires": {
         "bitsyntax": "~0.1.0",
         "bluebird": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/pagerinc/jackrabbit",
   "bugs": "https://github.com/pagerinc/jackrabbit/issues",
   "main": "lib/jackrabbit.js",
-  "scripts": {  
+  "scripts": {
     "test": "mocha",
     "lint": "eslint lib/** test/**"
   },
@@ -41,7 +41,6 @@
   },
   "mocha": {
     "bail": true,
-    "exit": true,
     "recursive": true
   }
 }

--- a/test/jackrabbit.test.js
+++ b/test/jackrabbit.test.js
@@ -3,33 +3,31 @@
 const Assert = require('chai').assert;
 const Jackrabbit = require('../lib/jackrabbit');
 
-const { after, before, describe, it } = require('mocha');
+const { after, afterEach, before, beforeEach, describe, it } = require('mocha');
 
 describe('jackrabbit', () => {
+
+    let rabbit;
+
+    beforeEach((done) => {
+
+        rabbit = Jackrabbit(process.env.RABBIT_URL);
+        rabbit.once('connected', done);
+    });
+
+    afterEach((done) => {
+
+        rabbit.close(done);
+    });
 
     describe('constructor', () => {
 
         describe('with a valid server url', () => {
 
-            before(() => {
-
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-            });
-
-            it('emits a "connected" event', (done) => {
-
-                this.r.once('connected', done);
-            });
-
             it('references a Connection object', () => {
 
-                const c = this.r.getInternals().connection;
+                const c = rabbit.getInternals().connection;
                 Assert.ok(c.connection.stream.writable);
-            });
-
-            after((done) => {
-
-                this.r.close(done);
             });
         });
 
@@ -57,86 +55,69 @@ describe('jackrabbit', () => {
 
         describe('without a "name" argument', () => {
 
-            before(() => {
+            let exchange;
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = this.r.default();
+            beforeEach(() => {
+
+                exchange = rabbit.default();
             });
 
             it('returns a direct, nameless exchange', () => {
 
-                Assert.ok(this.e.queue);
-                Assert.ok(this.e.publish);
-                Assert.equal(this.e.type, 'direct');
-                Assert.equal(this.e.name, '');
-            });
-
-            after((done) => {
-
-                this.r.close(done);
+                Assert.ok(exchange.queue);
+                Assert.ok(exchange.publish);
+                Assert.equal(exchange.type, 'direct');
+                Assert.equal(exchange.name, '');
             });
         });
 
         describe('with a "name" argument', () => {
 
+            let exchange;
+
             before(() => {
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = this.r.default('foobar');
+                exchange = rabbit.default('foobar');
             });
 
             it('returns a direct, nameless exchange', () => {
 
-                Assert.ok(this.e.queue);
-                Assert.ok(this.e.publish);
-                Assert.equal(this.e.type, 'direct');
-                Assert.equal(this.e.name, '');
-            });
-
-            after((done) => {
-
-                this.r.close(done);
+                Assert.ok(exchange.queue);
+                Assert.ok(exchange.publish);
+                Assert.equal(exchange.type, 'direct');
+                Assert.equal(exchange.name, '');
             });
         });
 
         describe('before connection is established', () => {
 
-            before(() => {
+            let beforeRabbit;
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
+            beforeEach(() => {
+
+                beforeRabbit = Jackrabbit(process.env.RABBIT_URL);
             });
 
             it('passes the connection to the exchange', (done) => {
 
-                this.r
+                beforeRabbit
                     .default()
                     .once('connected', done);
             });
 
-            after((done) => {
+            afterEach((done) => {
 
-                this.r.close(done);
+                beforeRabbit.close(done);
             });
         });
 
         describe('after connection is established', () => {
 
-            before((done) => {
-
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.r.once('connected', done);
-            });
-
             it('passes the connection to the exchange', (done) => {
 
-                this.r
+                rabbit
                     .default()
                     .once('connected', done);
-            });
-
-            after((done) => {
-
-                this.r.close(done);
             });
         });
     });
@@ -145,86 +126,69 @@ describe('jackrabbit', () => {
 
         describe('without a "name" argument', () => {
 
-            before(() => {
+            let exchange;
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = this.r.direct();
+            beforeEach(() => {
+
+                exchange = rabbit.direct();
             });
 
             it('returns the direct exchange named "amq.direct"', () => {
 
-                Assert.ok(this.e.queue);
-                Assert.ok(this.e.publish);
-                Assert.equal(this.e.type, 'direct');
-                Assert.equal(this.e.name, 'amq.direct');
-            });
-
-            after((done) => {
-
-                this.r.close(done);
+                Assert.ok(exchange.queue);
+                Assert.ok(exchange.publish);
+                Assert.equal(exchange.type, 'direct');
+                Assert.equal(exchange.name, 'amq.direct');
             });
         });
 
         describe('with a "name" argument of "foobar.direct"', () => {
 
-            before(() => {
+            let exchange;
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = this.r.direct('foobar.direct');
+            beforeEach(() => {
+
+                exchange = rabbit.direct('foobar.direct');
             });
 
             it('returns a direct exchange named "foobar.direct"', () => {
 
-                Assert.ok(this.e.queue);
-                Assert.ok(this.e.publish);
-                Assert.equal(this.e.type, 'direct');
-                Assert.equal(this.e.name, 'foobar.direct');
-            });
-
-            after((done) => {
-
-                this.r.close(done);
+                Assert.ok(exchange.queue);
+                Assert.ok(exchange.publish);
+                Assert.equal(exchange.type, 'direct');
+                Assert.equal(exchange.name, 'foobar.direct');
             });
         });
 
         describe('before connection is established', () => {
 
+            let beforeRabbit;
+
             before(() => {
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
+                beforeRabbit = Jackrabbit(process.env.RABBIT_URL);
             });
 
             it('passes the connection to the exchange', (done) => {
 
-                this.r
+                beforeRabbit
                     .direct()
                     .once('connected', done);
             });
 
             after((done) => {
 
-                this.r.close(done);
+                beforeRabbit.close(done);
             });
         });
 
         describe('after connection is established', () => {
 
-            before((done) => {
-
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.r.once('connected', done);
-            });
-
             it('passes the connection to the exchange', (done) => {
 
-                this.r
+                rabbit
                     .direct()
                     .once('connected', done);
-            });
-
-            after((done) => {
-
-                this.r.close(done);
             });
         });
     });
@@ -233,113 +197,85 @@ describe('jackrabbit', () => {
 
         describe('without a "name" argument', () => {
 
+            let exchange;
+
             before(() => {
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = this.r.fanout();
+                exchange = rabbit.fanout();
             });
 
             it('returns the direct exchange named "amq.fanout"', () => {
 
-                Assert.ok(this.e.queue);
-                Assert.ok(this.e.publish);
-                Assert.equal(this.e.type, 'fanout');
-                Assert.equal(this.e.name, 'amq.fanout');
-            });
-
-            after((done) => {
-
-                this.r.close(done);
+                Assert.ok(exchange.queue);
+                Assert.ok(exchange.publish);
+                Assert.equal(exchange.type, 'fanout');
+                Assert.equal(exchange.name, 'amq.fanout');
             });
         });
 
         describe('with a "name" argument of "foobar.fanout"', () => {
 
+            let exchange;
+
             before(() => {
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.e = this.r.fanout('foobar.fanout');
+                exchange = rabbit.fanout('foobar.fanout');
             });
 
             it('returns a direct exchange named "foobar.fanout"', () => {
 
-                Assert.ok(this.e.queue);
-                Assert.ok(this.e.publish);
-                Assert.equal(this.e.type, 'fanout');
-                Assert.equal(this.e.name, 'foobar.fanout');
-            });
-
-            after((done) => {
-
-                this.r.close(done);
+                Assert.ok(exchange.queue);
+                Assert.ok(exchange.publish);
+                Assert.equal(exchange.type, 'fanout');
+                Assert.equal(exchange.name, 'foobar.fanout');
             });
         });
 
         describe('before connection is established', () => {
 
+            let beforeRabbit;
 
             before(() => {
 
-                this.r = Jackrabbit(process.env.RABBIT_URL);
+                beforeRabbit = Jackrabbit(process.env.RABBIT_URL);
             });
 
             it('passes the connection to the exchange', (done) => {
 
-                this.r
+                beforeRabbit
                     .fanout()
                     .once('connected', done);
             });
 
             after((done) => {
 
-                this.r.close(done);
+                beforeRabbit.close(done);
             });
         });
 
         describe('after connection is established', () => {
 
-            before((done) => {
-
-                this.r = Jackrabbit(process.env.RABBIT_URL);
-                this.r.once('connected', done);
-            });
-
             it('passes the connection to the exchange', (done) => {
 
-                this.r
+                rabbit
                     .fanout()
                     .once('connected', done);
-            });
-
-            after((done) => {
-
-                this.r.close(done);
             });
         });
     });
 
     describe('#close', () => {
 
-        before((done) => {
+        it('clears the connection', (done) => {
 
-            this.r = Jackrabbit(process.env.RABBIT_URL);
-            this.r.once('connected', done);
-        });
+            rabbit.close(() => {
 
-        it('emits a "close" event', (done) => {
+                rabbit.getInternals().connection.on('close', () => {
 
-            this.r.once('close', done);
-            this.r.close();
-        });
-
-        it('clears the connection', () => {
-
-            Assert.ok(!this.r.getInternals().connection);
-        });
-
-        after((done) => {
-
-            this.r.close(done);
+                    Assert.ok(!rabbit.getInternals().connection);
+                    done();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
- dockerfile for use with `docker-compose` build step
- bump circleci image tag
- *major* test refactor: tests perform the same assertions but now clean up in several ways:
  - all connections are specific to each test, shared connections and timing issues were minimized
  - connections and queues are created and removed\closed after each test. this allows us to remove the `exit: true` crutch in mocha. tests now pass without it because connections aren't left open
  - updated a lot of testing faux pas:
    - randomness: no more `Uuid()`
    - shared state: each test now scaffolds and destroys state
    - expectations on order of tests: tests were relying on prior tests to check and build off of one another
    - ambiguous assertions: instead of `value > 5`, do something like `value === 5`

addresses https://github.com/pagerinc/jackrabbit/issues/63