### PR TITLE
fix: remove race condition between rabbitmq connection queue.consume

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -27,20 +27,7 @@ const queue = (options) => {
 
     const consume = (callback, consumeOptions) => {
 
-        if ( ready ){
-            const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
-            channel.consume(emitter.name, onMessage, opts, onConsume);
-            return;
-        }
-
-
-        emitter.once('ready', () => {
-
-            const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
-            channel.consume(emitter.name, onMessage, opts, onConsume);
-        });
-
-        function onMessage(msg){
+        const onMessage = (msg) => {
 
             const data = parseMessage(msg);
             if (!data) {
@@ -72,6 +59,20 @@ const queue = (options) => {
 
             callback(data, ack, nack, msg);
         }
+
+        if ( ready ){
+
+            const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
+            channel.consume(emitter.name, onMessage, opts, onConsume);
+            return;
+        }
+
+
+        emitter.once('ready', () => {
+
+            const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
+            channel.consume(emitter.name, onMessage, opts, onConsume);
+        });
     };
 
     const cancel = (done) => {

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -58,7 +58,7 @@ const queue = (options) => {
             };
 
             callback(data, ack, nack, msg);
-        }
+        };
 
         if ( ready ){
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -30,16 +30,17 @@ const queue = (options) => {
         if ( ready ){
             const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
             channel.consume(emitter.name, onMessage, opts, onConsume);
-        }
-        else {
-            emitter.once('ready', () => {
-
-                const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
-                channel.consume(emitter.name, onMessage, opts, onConsume);
-            });
+            return;
         }
 
-        const onMessage = (msg) => {
+
+        emitter.once('ready', () => {
+
+            const opts = Extend({}, DEFAULT_CONSUME_OPTIONS, consumeOptions);
+            channel.consume(emitter.name, onMessage, opts, onConsume);
+        });
+
+        function onMessage(msg){
 
             const data = parseMessage(msg);
             if (!data) {
@@ -70,7 +71,7 @@ const queue = (options) => {
             };
 
             callback(data, ack, nack, msg);
-        };
+        }
     };
 
     const cancel = (done) => {


### PR DESCRIPTION
Should fix this issue: https://github.com/pagerinc/jackrabbit/issues/87

Changed `onMessage` from variable with anonymous function assigned to it to hoisted named function.

No need to change structure of the code, just `onMessage`'s type.

Also changed a nearby if/else to early exit style.