### PR TITLE
feat: noReply default true

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -14,7 +14,7 @@ const DEFAULT_EXCHANGES = {
 
 const DEFAULT_EXCHANGE_OPTIONS = {
     durable: true,
-    noReply: false,
+    noReply: true,
     internal: false,
     autoDelete: false,
     alternateExchange: undefined

--- a/test/exchange.test.js
+++ b/test/exchange.test.js
@@ -125,16 +125,38 @@ describe('exchange', () => {
 
         describe('with key bindings', () => {
 
-            let exchange;
+            it('does not create a reply queue by default', (done) => {
 
-            beforeEach((done) => {
+                const exchange = Exchange('test.topic.replyQueue', 'topic')
+                    .connect(connection);
 
-                exchange = Exchange('test.topic.bindings', 'topic')
-                    .connect(connection)
-                    .once('connected', done);
+                exchange.on('ready', () => {
+
+                    const channelWithReply = connection.connection.channels.filter((channel) => channel.channel.reply);
+                    Assert.lengthOf(channelWithReply, 0);
+                    done();
+                });
+            });
+
+            it('creates a reply queue if configured', (done) => {
+
+                const exchange = Exchange('test.topic.replyQueue', 'topic', { noReply: false })
+                    .connect(connection);
+
+                exchange.on('ready', () => {
+
+                    const channelWithReply = connection.connection.channels.filter((channel) => channel.channel.reply);
+                    Assert.lengthOf(channelWithReply, 1);
+                    Assert.exists(channelWithReply[0].channel.reply);
+                    done();
+                });
             });
 
             it('emits a "bound" event when all routing keys have been bound to the queue', (done) => {
+
+                const exchange = Exchange('test.topic.bindings', 'topic')
+                    .connect(connection)
+                    .once('connected', done);
 
                 const keys = 'abcdefghijklmnopqrstuvwxyz'.split('');
                 const finalKey = keys[keys.length - 1];

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -70,9 +70,12 @@ describe('queue', () => {
 
             queue.consume(onMessage, { noAck: true });
 
-            for (let i = 0; i < n; ++i) {
-                exchange.publish(message, { key: name });
-            }
+            queue.on('ready', () => {
+
+                for (let i = 0; i < n; ++i) {
+                    exchange.publish(message, { key: name });
+                }
+            });
         });
 
         it('calls back with ok', (done) => {
@@ -92,7 +95,10 @@ describe('queue', () => {
             const message = Uuid();
 
             queue.consume(onMessage, { noAck: true });
-            exchange.publish(message, { key: name });
+            queue.on('ready', () => {
+
+                exchange.publish(message, { key: name });
+            });
         });
     });
 
@@ -145,7 +151,7 @@ describe('queue', () => {
 
             name = `test.queue.purge`;
             queue = Queue({ name, durable: false, exclusive: true });
-            queue.on('connected', () => {
+            queue.on('ready', () => {
 
                 messageCount = 10;
                 for (let i = 0; i < messageCount; ++i) {


### PR DESCRIPTION
request-reply as a default configuration does not make sense for rabbit's core use cases + scenarios. For a given exchange, you will see many of the following in your queue list:

![image](https://user-images.githubusercontent.com/885563/72541431-83eb5a80-3850-11ea-873f-6cc0cc32ed76.png)

 If you use jackrabbit heavily across many services, the default reply queues create a ton of overhead and noise for queue management. This change is a breaking change, so it will have a commensurate major version bump

This PR also includes a few updates to test reliability, namely ensuring test queues are `ready` and not just `connected` before publishing messages for their consumption. Before tests would intermittently fail in a race condition that the queue was connected but not ready, and messages meant for their consumption were published.