### PR TITLE
fix: check if properties is null in msg

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -121,7 +121,7 @@ const queue = (options) => {
 
     const parseMessage = (msg) => {
 
-        if (msg.properties.contentType === 'application/json') {
+        if (msg.properties && msg.properties.contentType === 'application/json') {
             try {
                 return JSON.parse(msg.content.toString());
             }


### PR DESCRIPTION
Check if propertis is null in message to prevent this error:

`TypeError: Cannot read property 'properties' of null at parseMessage (/home/node/app/node_modules/@pager/jackrabbit/lib/queue.js:124:17) at onMessage (/home/node/app/node_modules/@pager/jackrabbit/lib/queue.js:32:26) at createConsumeTrans (/home/node/app/node_modules/newrelic/lib/shim/message-shim.js:734:27) at MessageShim.applySegment (/home/node/app/node_modules/newrelic/lib/shim/shim.js:1425:20) at nestedTransactionWrapper (/home/node/app/node_modules/newrelic/lib/shim/transaction-shim.js:579:17) at Channel.BaseChannel.dispatchMessage (/home/node/app/node_modules/amqplib/lib/channel.js:484:12) at Channel.BaseChannel.handleCancel (/home/node/app/node_modules/amqplib/lib/channel.js:497:15) at Channel.emit (events.js:310:20) at Channel.EventEmitter.emit (domain.js:482:12) at Channel.C.accept (/home/node/app/node_modules/amqplib/lib/channel.js:409:17) at Connection.mainAccept [as accept] (/home/node/app/node_modules/amqplib/lib/connection.js:64:33) at Socket.go (/home/node/app/node_modules/amqplib/lib/connection.js:478:48) at Socket.emit (events.js:310:20) at Socket.EventEmitter.emit (domain.js:482:12) at emitReadable_ (_stream_readable.js:543:12) at processTicksAndRejections (internal/process/task_queues.js:83:21)`