### PR TITLE
feat: handle backpressure with streams [PSS-330]

### DIFF
--- a/lib/exchange.js
+++ b/lib/exchange.js
@@ -3,6 +3,7 @@
 const Extend = require('lodash.assignin');
 const { EventEmitter, once } = require('events');
 const { v4: Uuid } = require('uuid');
+const { Writable } = require('stream');
 
 const Queue = require('./queue');
 
@@ -178,6 +179,23 @@ const exchange = (name, type, exchangeOptions) => {
         }
 
         return newQueue;
+    };
+
+    const getWritableStream = () => {
+
+        return new Writable({
+            objectMode: true,
+            write({ key, data, headers }, encoding, cb) {
+
+                const ok = sendMessage(data, { key, headers });
+                if (ok) {
+                    process.nextTick(cb);
+                }
+                else {
+                    channel.once('drain', cb);
+                }
+            }
+        });
     };
 
     const publishSafe = async (message, publishOptions) => {
@@ -407,6 +425,7 @@ const exchange = (name, type, exchangeOptions) => {
         connect,
         publish,
         publishSafe,
+        getWritableStream,
         rpcClient,
         rpcServer
     });


### PR DESCRIPTION
To make the most of massiveJs streaming capabilities, we can return a writable stream from Jackrabbit and let the Streams API handle backpressure. In `event-sourcerer` the replay code would look like this
```
    const eventsStream = await db.events.events.find({
        stream,
        'created_as_of BETWEEN': [asOfAfter, asOfBefore]
    }, {
        order: [{ field: 'created_as_of' }],
        stream: true
    });

    const formatEvents = // Transform stream to format headers and data fields

    const exchangeStream = exchange.getWritableStream();

    eventsStream
        .pipe(formatEvents)
        .pipe(exchangeStream);
```

