### PR TITLE
feat: add isConnectionReady function [UE-2535]

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,15 @@
+'use strict';
+
 module.exports = {
-  extends: 'hapi',
-  parserOptions: {
-    ecmaVersion: 9
-  },
-  rules: {},
-  globals: {
-    describe: true,
-    it: true,
-    beforeEach: true,
-    afterEach: true
-  }
-}
+    extends: 'hapi',
+    parserOptions: {
+        ecmaVersion: 2020
+    },
+    rules: {},
+    globals: {
+        describe: true,
+        it: true,
+        beforeEach: true,
+        afterEach: true
+    }
+};

--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -13,6 +13,7 @@ const jackrabbit = (url) => {
 
     // state
     let connection;
+    let isConnected;
     const pendingExchangesForConnection = [];
 
     // public
@@ -23,6 +24,19 @@ const jackrabbit = (url) => {
             amqp: Amqp,
             connection
         };
+    };
+
+    const ping = () => {
+
+        if (!connection) {
+            throw new Error('no connection established');
+        } else if (!connection.connection.stream.writable){
+            throw new Error('connection not capable to write');
+        } else if (!isConnected) {
+            throw new Error('connection experimenting heartbeat problems');
+        }
+
+        return true;
     };
 
     const close = (callback) => {
@@ -82,6 +96,7 @@ const jackrabbit = (url) => {
 
         // TODO close any connections or channels that remain open
         connection = undefined;
+        isConnected = false;
         if (err) {
             rabbit.emit('error', err);
         }
@@ -94,9 +109,14 @@ const jackrabbit = (url) => {
         }
 
         connection = conn;
+        isConnected = true;
         connection.on('close', bail.bind(this));
         connection.on('blocked', (cause) => rabbit.emit('blocked', cause));
         connection.on('unblocked', () => rabbit.emit('unblocked'));
+
+        connection.connection.heartbeater.on('beat', () => { isConnected = true; });
+        connection.connection.heartbeater.on('timeout', () => { isConnected = false; });
+
         pendingExchangesForConnection.forEach((exchange) => {
             exchange.connect(connection);
         });

--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -13,7 +13,6 @@ const jackrabbit = (url) => {
 
     // state
     let connection;
-    let isConnected;
     const pendingExchangesForConnection = [];
 
     // public
@@ -26,14 +25,12 @@ const jackrabbit = (url) => {
         };
     };
 
-    const ping = () => {
+    const isConnectionReady = () => {
 
         if (!connection) {
             throw new Error('no connection established');
         } else if (!connection.connection.stream.writable){
             throw new Error('connection not capable to write');
-        } else if (!isConnected) {
-            throw new Error('connection experimenting heartbeat problems');
         }
 
         return true;
@@ -96,7 +93,6 @@ const jackrabbit = (url) => {
 
         // TODO close any connections or channels that remain open
         connection = undefined;
-        isConnected = false;
         if (err) {
             rabbit.emit('error', err);
         }
@@ -109,13 +105,9 @@ const jackrabbit = (url) => {
         }
 
         connection = conn;
-        isConnected = true;
         connection.on('close', bail.bind(this));
         connection.on('blocked', (cause) => rabbit.emit('blocked', cause));
         connection.on('unblocked', () => rabbit.emit('unblocked'));
-
-        connection.connection.heartbeater.on('beat', () => { isConnected = true; });
-        connection.connection.heartbeater.on('timeout', () => { isConnected = false; });
 
         pendingExchangesForConnection.forEach((exchange) => {
             exchange.connect(connection);
@@ -130,7 +122,8 @@ const jackrabbit = (url) => {
         topic: createExchange().bind(null, 'topic'),
         exchange: createExchange(),
         close,
-        getInternals
+        getInternals,
+        isConnectionReady
     });
 
     Amqp.connect(url, onConnection);

--- a/lib/jackrabbit.js
+++ b/lib/jackrabbit.js
@@ -29,7 +29,7 @@ const jackrabbit = (url) => {
 
         if (!connection) {
             throw new Error('no connection established');
-        } else if (!connection.connection.stream.writable){
+        } else if (!connection.connection?.stream?.writable){
             throw new Error('connection not capable to write');
         }
 

--- a/test/jackrabbit.test.js
+++ b/test/jackrabbit.test.js
@@ -26,9 +26,12 @@ describe('jackrabbit', () => {
 
             it('references a Connection object', () => {
 
-                const c = rabbit.getInternals().connection;
+                const internals = rabbit.getInternals();
+                const c = internals.connection;
                 Assert.ok(c.connection.stream.writable);
+                Assert.ok(rabbit.isConnectionReady());
             });
+
         });
 
         describe('without a server url', () => {
@@ -273,6 +276,14 @@ describe('jackrabbit', () => {
                 rabbit.getInternals().connection.on('close', () => {
 
                     Assert.ok(!rabbit.getInternals().connection);
+
+                    try {
+                        Assert.ok(!rabbit.isConnectionReady());
+                    }
+                    catch (err) {
+                        Assert.equal('no connection established', err.message);
+                    }
+
                     done();
                 });
             });


### PR DESCRIPTION
UE-2535

[amqp library](https://github.com/squaremo/amqp.node/blob/32aa2025a20200d0df861d5520bb263ba7b10523/lib/connection.js#L430) will close the connection if heartbeat fails.
If that happens a `close` event will be dispatched and the local lister will delete the internal connection.