### PR TITLE
fix: allow empty payloads

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -32,9 +32,6 @@ const queue = (options) => {
         const onMessage = (msg) => {
 
             const data = parseMessage(msg);
-            if (!data) {
-                return;
-            }
 
             const ack = (reply) => {
 

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -101,6 +101,19 @@ describe('queue', () => {
                 exchange.publish(message, { key: name });
             });
         });
+
+        it('consumes empty payloads', (done) => {
+
+            queue.consume((data) => {
+
+                Assert.equal(data, null);
+                done();
+            });
+            queue.on('ready', () => {
+
+                exchange.publish(null, { key: name });
+            });
+        });
     });
 
     describe('cancel', () => {


### PR DESCRIPTION
[ENG-7564](https://pagerinc.atlassian.net/browse/ENG-7564)

If a payload is empty or is malformed JSON, then the consumer callback should still be invoked (with the empty payload). If an empty payload was not expected, then downstream validation can NACK the message.
